### PR TITLE
Fix usage on high DPI screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang = "eng">
 <head>
 	<meta charset="UTF-8">
@@ -19,7 +19,7 @@
 <body style="font-family: Tahoma, Geneva, sans-serif">
 	<h1 class="content">Finite State Machine Builder</h1>
 	<div style="max-width:1300px;margin-left:auto;margin-right:auto;">
-		<canvas id = "canvas" tabindex="1" oncontextmenu="return false;">
+		<canvas id = "canvas" tabindex="1" width="2000" height="1000">
 			This browser does not support HTML5 canvas
         </canvas>
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -63,6 +63,7 @@ function drawScreen(){
 		hideArrowMenu();
 	}
 
+	//DEBUG
 	// if(CM.nodes.length > 0){
 	// 	drawLine(IM.mouse_pos, CM.nodes[0].pos );
 	// }
@@ -89,7 +90,8 @@ function distanceToClosestNode(){
 
 	let IM = inputManager.getInstance();
 
-	return getDistance(IM.mouse_pos, getClosestNode().pos);
+	let t = IM.mouse_pos.product(1);
+	return getDistance(t, getClosestNode().pos);
 }
 
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -90,7 +90,6 @@ function distanceToClosestNode(){
 
 	let IM = inputManager.getInstance();
 
-	let t = IM.mouse_pos.product(1);
 	return getDistance(t, getClosestNode().pos);
 }
 

--- a/src/elements.js
+++ b/src/elements.js
@@ -313,9 +313,9 @@ class Arrow{
 
 
     isMouseOver(){  
-        let mp = inputManager.getInstance().mouse_pos;
+        let mp = inputManager.getInstance().mouse_pos.product( window.devicePixelRatio );
         return canvasManager.getInstance().context.isPointInStroke( 
-            this.hooverPath, mp.X, mp.Y 
+            this.hooverPath, mp.X, mp.Y
         );
     }
 

--- a/src/input.js
+++ b/src/input.js
@@ -1,5 +1,5 @@
 import {API} from './api.js';
-import {transformPoint, Point} from './lib/geometry.js';
+import {Point} from './lib/geometry.js';
 import {isOverNode, getClosestNode, refocus} from './canvas.js';
 import {canvasManager} from './canvasManager.js';
 import {step, addRow} from './simulate.js';
@@ -175,13 +175,10 @@ function onMouseDown(e){
 
 
 function onMouseMove(e){
-    API.call("mouse_move", e);
-
     let IM = inputManager.getInstance();
     let CM = canvasManager.getInstance();
 
     IM.mouse_pos = getMouse(e);
-
     IM.is_dragging = IM.is_mouse_down;
     
     if(CM.nodes.length == 0 || IM.is_key_down) {
@@ -346,7 +343,8 @@ function hideArrowMenu(){
 * @returns {Point}
 */
 function getMouse(pos){
-    return transformPoint(new Point(pos.offsetX, pos.offsetY));
+    let ratio = window.devicePixelRatio; 
+    return new Point(pos.offsetX, pos.offsetY)  ;
 }
 
 /** @typedef { import('./lib/geometry.js').Point } Point */

--- a/src/lib/geometry.js
+++ b/src/lib/geometry.js
@@ -1,4 +1,3 @@
-import {getDeviceRatio} from '../renderer.js';
 
 /** 
 * point represents 2D position
@@ -22,6 +21,10 @@ class Point{
         this.X = X_;
         this.Y = Y_;
         return this;
+    }
+
+    product(m){
+        return new Point( this.X * m, this.Y * m );
     }
 }
 
@@ -89,29 +92,8 @@ function matrixDot (A, B) {
     });
 }
 
-
-/**
-* transform the mouse position to match the initial canvas transformation
-*
-* @param {Point} p
-* @returns {Point}
-*/
-function transformPoint(p){
-    let ratio = getDeviceRatio();
-    //use the transformation matrix to get the real canvas position
-    let m = matrixDot(
-        [[p.X, p.Y]], 
-        [[ratio, 0, 0 ], 
-         [0, ratio, 0], 
-         [0,0,1]]
-    )[0];
-
-    return new Point(m[0]/ratio,m[1]/ratio);
-}
-
 export{
     Point,
-    transformPoint,
     getDistance,
     findAngle,
     getMidPoint

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -76,43 +76,16 @@ function drawSelfArrowHelper(start_pos){
 } 
 
 
-/** returns the device's pixel ratio for HiDPI displays */
-function getDeviceRatio () {
-    let CM = canvasManager.getInstance();
-    let dpr = window.devicePixelRatio || 1;
-    let bsr = CM.context.webkitBackingStorePixelRatio ||
-        CM.context.mozBackingStorePixelRatio ||
-        CM.context.msBackingStorePixelRatio ||
-        CM.context.oBackingStorePixelRatio ||
-        CM.context.backingStorePixelRatio || 1;
-
-    //TODO: fix
-    return 1;
-    //return dpr / bsr;
-}
-
-
-/**
-* https://stackoverflow.com/questions/
-* 15661339/how-do-i-fix-blurry-text-in-my-html5-canvas
-*/
 function initCanvas() {
-    let ratio = getDeviceRatio();
+    let ratio = window.devicePixelRatio;
     let CM = canvasManager.getInstance();
-    CM.canvas.width = CM.width * ratio;
-    CM.canvas.height = CM.height * ratio;
     CM.canvas.style.width = CM.width + "px";
     CM.canvas.style.height = CM.height + "px";
-    //                    a     b  c  d      e  f
-    CM.context.setTransform(ratio, 0, 0, ratio, 0, 0);
-    /**
-    [ a c e 
-      b d f
-      0 0 1
-    ]
-    */
-
-    if(API.config["light-mode"] === false){
+ 
+    CM.canvas.width = CM.width * ratio;
+    CM.canvas.height = CM.height * ratio;
+    CM.context.scale(ratio, ratio);
+   if(API.config["light-mode"] === false){
         displayDarkMode();
     }
 }
@@ -191,7 +164,6 @@ function renderBackground(){
 
 export{
     initCanvas,
-    getDeviceRatio,
     drawArrowhead,
     drawSelfArrowHelper,
     drawLine,


### PR DESCRIPTION
High DPI screens would previously be blurry since the old method of scaling up the canvas could not have been used.

Refactored method to scale up canvas should now work with high dpi and regular screens while looking crisp on both 