### PR TITLE
Fixes issue with creating arrows between nodes

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -39,13 +39,13 @@ function drawScreen(){
 	isOverNode();
 	CM.is_over_arrow = false;
 
-	if(CM.is_starting_arrow && CM.current_node){
+	if(CM.is_starting_arrow){
 		if(CM.is_over_node && (getClosestNode() == CM.start_node) ){
 			drawSelfArrowHelper(CM.start_node.pos);
 		}
 
-		drawLine(CM.current_node.pos, IM.mouse_pos);
-		CM.current_node.draw();
+		drawLine(CM.start_node.pos, IM.mouse_pos);
+		//CM.start_node.draw();
 	}
 
 	for(let i = 0; i < CM.arrows.length; ++i){

--- a/src/input.js
+++ b/src/input.js
@@ -169,7 +169,7 @@ function onMouseUp(e){
 
     if(e.button === IM.RIGHT_MOUSE_BUTTON){
         //remove all conections from this node
-        if(CM.is_over_node){
+        if(isOverNode()){
             CM.deleteNode(getClosestNode());
         }
 
@@ -188,9 +188,9 @@ function onMouseUp(e){
 
     if(CM.is_starting_arrow){
         CM.is_starting_arrow = false;
-        if(CM.is_over_node){
+        if(isOverNode()){
             //if we landed on another node create a new arrow
-            CM.addNewArrow(CM.current_node, getClosestNode());
+            CM.addNewArrow(CM.start_node, getClosestNode());
         }
     }
     

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -143,7 +143,6 @@ function drawText(str, _pos){
 function drawLine(a, b, thickness = 1){
     let CM = canvasManager.getInstance();
     CM.context.strokeStyle = API.config["light-mode"] ? "black" : "white";
-
     CM.context.beginPath();
     CM.context.moveTo(a.X,a.Y);
     CM.context.lineTo(b.X,b.Y);


### PR DESCRIPTION
Was using `current_node` instead of `starting_node` which would be null while not hoovering over a node.
Recalc, check if over node when mouse is released and in the state of `starting_arrow` 