### PR TITLE
Move node versions together and increase to v12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  NODE_VERSION: 12
+
 jobs:
   publish:
     needs : [unit-testing, e2e-testing]
@@ -10,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version:  ${{ env.NODE_VERSION }}
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -31,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.2
         with:
-          node-version: '10'
+          node-version:  ${{ env.NODE_VERSION }}
       - name: Cache Node Modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This PR moves together usage of the `node` version to an env var and upgrades to node v12